### PR TITLE
Handle non-fat frameworks and copy .swiftinterface and .swiftdocs

### DIFF
--- a/Sources/XCFrameworkNow/FrameworkParser.swift
+++ b/Sources/XCFrameworkNow/FrameworkParser.swift
@@ -1,55 +1,59 @@
 import Foundation
 
 public struct FrameworkInfo: GenericInfo {
-    
+
     public let baseUrl: URL
-    
+
     public let binaryUrl : URL
-    
+
     public var isDynamic: Bool = false
-    
+
     public var slices: [Slice] = .init()
-    
+
     public var binaryRelativePath: String {
         return baseUrl.lastPathComponent + "/" + binaryUrl.lastPathComponent
     }
-    
+
+    public var moduleUrlRelativePath: String? {
+        return "Modules/" + binaryUrl.lastPathComponent + ".swiftmodule"
+    }
+
 }
 
 public class FrameworkParser: GenericParser {
-    
+
     let path: String
-    
+
     public init(path: String) {
         self.path = path
     }
-    
+
     public typealias Info = FrameworkInfo
-    
+
     public func parse() -> FrameworkInfo? {
-        
+
         let frameworkUrl = URL(fileURLWithPath: path)
         let binaryName = frameworkUrl.deletingPathExtension().lastPathComponent
         let binaryUrl = frameworkUrl.appendingPathComponent(binaryName)
-        
+
         var info = FrameworkInfo(baseUrl: frameworkUrl, binaryUrl: binaryUrl)
-        
+
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: binaryUrl.path, isDirectory: &isDirectory),
               isDirectory.boolValue == false else {
             print("Binary not found at path: \(binaryUrl.path)")
             return nil
         }
-        
+
         info.isDynamic = isBinaryDynamic(at: binaryUrl)
-        
+
         if info.isDynamic {
             info.slices += parseDynamicBinary(at: binaryUrl)
         } else {
             info.slices += parseStaticBinary(at: binaryUrl)
         }
-        
+
         return info
     }
-    
+
 }

--- a/Sources/XCFrameworkNow/FrameworkParser.swift
+++ b/Sources/XCFrameworkNow/FrameworkParser.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public struct FrameworkInfo: GenericInfo {
-
+    
     public let baseUrl: URL
-
+    
     public let binaryUrl : URL
-
+    
     public var isDynamic: Bool = false
-
+    
     public var slices: [Slice] = .init()
-
+    
     public var binaryRelativePath: String {
         return baseUrl.lastPathComponent + "/" + binaryUrl.lastPathComponent
     }
@@ -21,39 +21,39 @@ public struct FrameworkInfo: GenericInfo {
 }
 
 public class FrameworkParser: GenericParser {
-
+    
     let path: String
-
+    
     public init(path: String) {
         self.path = path
     }
-
+    
     public typealias Info = FrameworkInfo
-
+    
     public func parse() -> FrameworkInfo? {
-
+        
         let frameworkUrl = URL(fileURLWithPath: path)
         let binaryName = frameworkUrl.deletingPathExtension().lastPathComponent
         let binaryUrl = frameworkUrl.appendingPathComponent(binaryName)
-
+        
         var info = FrameworkInfo(baseUrl: frameworkUrl, binaryUrl: binaryUrl)
-
+        
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: binaryUrl.path, isDirectory: &isDirectory),
               isDirectory.boolValue == false else {
             print("Binary not found at path: \(binaryUrl.path)")
             return nil
         }
-
+        
         info.isDynamic = isBinaryDynamic(at: binaryUrl)
-
+        
         if info.isDynamic {
             info.slices += parseDynamicBinary(at: binaryUrl)
         } else {
             info.slices += parseStaticBinary(at: binaryUrl)
         }
-
+        
         return info
     }
-
+    
 }

--- a/Sources/XCFrameworkNow/GenericInfo.swift
+++ b/Sources/XCFrameworkNow/GenericInfo.swift
@@ -1,33 +1,35 @@
 import Foundation
 
 public protocol GenericInfo {
-    
+
     var baseUrl: URL { get }
 
     var binaryUrl: URL { get }
-    
+
     var binaryRelativePath: String { get }
-    
+
+    var moduleUrlRelativePath: String? { get }
+
     var isDynamic: Bool { get set }
 
     var slices: [Slice] { get set }
-    
+
 }
 
 public struct Slice {
-    
+
     let arch: String
 
     let destination: Platform
-    
+
     let version: String
-    
+
     let sdk: String
-    
+
 }
 
 public enum Platform {
-    
+
     case macos
     case ios
     case tvos
@@ -36,7 +38,7 @@ public enum Platform {
     case iossimulator
     case tvossimulator
     case watchossimulator
-    
+
     init?(string: String) {
         switch string {
         case "MACOS", "\(PLATFORM_MACOS)": self = .macos
@@ -50,7 +52,7 @@ public enum Platform {
         default: return nil
         }
     }
-    
+
     init?(loadCommand: String, arch: String) {
         let isArchARM = arch.hasPrefix("arm")
         switch loadCommand {
@@ -61,7 +63,7 @@ public enum Platform {
         default: return nil
         }
     }
-    
+
     func numericValue() -> Int32 {
         switch self {
         case .macos: return PLATFORM_MACOS
@@ -74,7 +76,7 @@ public enum Platform {
         case .watchossimulator: return PLATFORM_WATCHOSSIMULATOR
         }
     }
-    
+
     func stringValue() -> String {
         switch self {
         case .macos: return "macos"
@@ -87,7 +89,7 @@ public enum Platform {
         case .watchossimulator: return "watchossimulator"
         }
     }
-    
+
     func simulatorVariant() -> Platform? {
         switch self {
         case .ios: return .iossimulator
@@ -96,5 +98,5 @@ public enum Platform {
         default: return nil
         }
     }
-    
+
 }

--- a/Sources/XCFrameworkNow/GenericInfo.swift
+++ b/Sources/XCFrameworkNow/GenericInfo.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public protocol GenericInfo {
-
+    
     var baseUrl: URL { get }
 
     var binaryUrl: URL { get }
-
+    
     var binaryRelativePath: String { get }
 
     var moduleUrlRelativePath: String? { get }
@@ -13,23 +13,23 @@ public protocol GenericInfo {
     var isDynamic: Bool { get set }
 
     var slices: [Slice] { get set }
-
+    
 }
 
 public struct Slice {
-
+    
     let arch: String
 
     let destination: Platform
-
+    
     let version: String
-
+    
     let sdk: String
-
+    
 }
 
 public enum Platform {
-
+    
     case macos
     case ios
     case tvos
@@ -38,7 +38,7 @@ public enum Platform {
     case iossimulator
     case tvossimulator
     case watchossimulator
-
+    
     init?(string: String) {
         switch string {
         case "MACOS", "\(PLATFORM_MACOS)": self = .macos
@@ -52,7 +52,7 @@ public enum Platform {
         default: return nil
         }
     }
-
+    
     init?(loadCommand: String, arch: String) {
         let isArchARM = arch.hasPrefix("arm")
         switch loadCommand {
@@ -63,7 +63,7 @@ public enum Platform {
         default: return nil
         }
     }
-
+    
     func numericValue() -> Int32 {
         switch self {
         case .macos: return PLATFORM_MACOS
@@ -76,7 +76,7 @@ public enum Platform {
         case .watchossimulator: return PLATFORM_WATCHOSSIMULATOR
         }
     }
-
+    
     func stringValue() -> String {
         switch self {
         case .macos: return "macos"
@@ -89,7 +89,7 @@ public enum Platform {
         case .watchossimulator: return "watchossimulator"
         }
     }
-
+    
     func simulatorVariant() -> Platform? {
         switch self {
         case .ios: return .iossimulator
@@ -98,5 +98,5 @@ public enum Platform {
         default: return nil
         }
     }
-
+    
 }

--- a/Sources/XCFrameworkNow/LibraryParser.swift
+++ b/Sources/XCFrameworkNow/LibraryParser.swift
@@ -21,7 +21,7 @@ public struct LibraryInfo: GenericInfo {
 }
 
 public class LibraryParser: GenericParser {
-
+    
     let path: String
     let headersPath: String?
 
@@ -29,40 +29,40 @@ public class LibraryParser: GenericParser {
         self.path = path
         self.headersPath = headersPath
     }
-
+    
     public typealias Info = LibraryInfo
-
+    
     public func parse() -> LibraryInfo? {
-
+        
         let libraryUrl = URL(fileURLWithPath: path)
         let binaryUrl = libraryUrl
         let headersUrl: URL?
-
+        
         if let headersPath = headersPath {
             headersUrl = URL(fileURLWithPath: headersPath)
         }
         else {
             headersUrl = nil
         }
-
+        
         var info = LibraryInfo(baseUrl: libraryUrl, binaryUrl: binaryUrl, headersUrl: headersUrl)
-
+        
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: binaryUrl.path, isDirectory: &isDirectory),
               isDirectory.boolValue == false else {
             print("Binary not found at path: \(binaryUrl.path)")
             return nil
         }
-
+        
         info.isDynamic = isBinaryDynamic(at: binaryUrl)
-
+        
         if info.isDynamic {
             info.slices += parseDynamicBinary(at: binaryUrl)
         } else {
             info.slices += parseStaticBinary(at: binaryUrl)
         }
-
+        
         return info
     }
-
+    
 }

--- a/Sources/XCFrameworkNow/LibraryParser.swift
+++ b/Sources/XCFrameworkNow/LibraryParser.swift
@@ -13,13 +13,15 @@ public struct LibraryInfo: GenericInfo {
     public var binaryRelativePath: String {
         return baseUrl.lastPathComponent
     }
-    
+
+    public var moduleUrlRelativePath: String? = nil
+
     public var headersUrl: URL?
 
 }
 
 public class LibraryParser: GenericParser {
-    
+
     let path: String
     let headersPath: String?
 
@@ -27,40 +29,40 @@ public class LibraryParser: GenericParser {
         self.path = path
         self.headersPath = headersPath
     }
-    
+
     public typealias Info = LibraryInfo
-    
+
     public func parse() -> LibraryInfo? {
-        
+
         let libraryUrl = URL(fileURLWithPath: path)
         let binaryUrl = libraryUrl
         let headersUrl: URL?
-        
+
         if let headersPath = headersPath {
             headersUrl = URL(fileURLWithPath: headersPath)
         }
         else {
             headersUrl = nil
         }
-        
+
         var info = LibraryInfo(baseUrl: libraryUrl, binaryUrl: binaryUrl, headersUrl: headersUrl)
-        
+
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: binaryUrl.path, isDirectory: &isDirectory),
               isDirectory.boolValue == false else {
             print("Binary not found at path: \(binaryUrl.path)")
             return nil
         }
-        
+
         info.isDynamic = isBinaryDynamic(at: binaryUrl)
-        
+
         if info.isDynamic {
             info.slices += parseDynamicBinary(at: binaryUrl)
         } else {
             info.slices += parseStaticBinary(at: binaryUrl)
         }
-        
+
         return info
     }
-    
+
 }

--- a/Sources/XCFrameworkNow/XCFrameworkPackager.swift
+++ b/Sources/XCFrameworkNow/XCFrameworkPackager.swift
@@ -123,7 +123,6 @@ public class XCFrameworkPackager {
             let (shellStatus, _) = shell(pwd: platformUrl.path, args: ["lipo"] + extractParams + ["-output", "\(libraryUrl.path)",  "\(info.binaryUrl.path)"])
             return shellStatus == 0 ? baseUrl : nil
         } else {
-            print("cmd = \(["cp", "\(info.binaryUrl.path)", "\(libraryUrl.path)"])")
             let (shellStatus, _) = shell(pwd: platformUrl.path, args: ["cp", "\(info.binaryUrl.path)", "\(libraryUrl.path)"])
             return shellStatus == 0 ? baseUrl : nil
         }

--- a/Sources/XCFrameworkNow/XCFrameworkPackager.swift
+++ b/Sources/XCFrameworkNow/XCFrameworkPackager.swift
@@ -201,7 +201,7 @@ public class XCFrameworkPackager {
 
             var (shellStatus, shellOutput) = shell(pwd: platformUrl.path, args: ["cp", "\(doc_src.path)", "\(doc_dst.path)"])
             if shellStatus != 0 {
-                print("Error generating swiftinterface: \(shellOutput)")
+                print("Error copying swiftdoc: \(shellOutput)")
             }
 
             let interface_src = info.baseUrl.appendingPathComponent(moduleUrlRelativePath).appendingPathComponent("\(slice.arch).swiftinterface")
@@ -209,12 +209,12 @@ public class XCFrameworkPackager {
 
             (shellStatus, shellOutput) = shell(pwd: platformUrl.path, args: ["sed", "-E", "s/(arm64-apple-ios[^ ]*)/\\1-simulator/", "\(interface_src.path)"])
             if shellStatus != 0 {
-                print("Error generating swiftdoc: \(shellOutput)")
+                print("Error generating swiftinterface: \(shellOutput)")
             } else {
                 do {
                     try shellOutput.write(to: interface_dst, atomically: true, encoding: String.Encoding.utf8)
                 } catch (let e) {
-                    print("Error writing swiftdoc: \(e)")
+                    print("Error writing swiftinterface: \(e)")
                 }
             }
         }


### PR DESCRIPTION
Thanks for the amazing tool! I had to make some changes to get it to support the frameworks I needed to use on m1, and wanted to contribute them back.

First main change is to support frameworks that do not have multiple slices in them. The current lipo -extract commands will fail when trying to extract. So I replaced those with a simple copy.

The second change is to copy over the .swiftdoc and .swiftinterface files for the new generated slice. Without this, xcode seems to know that the framework exists, but no symbols from it resolve.

The .swiftinterface file is also modified so that the swift-module-flags is referencing the simulator platform. Even though it's a comment, xcode appears to use it to generate linking instructions.

Thanks again!